### PR TITLE
pull-list-of-registered-users-feature

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -34,6 +34,7 @@ $router->group(['prefix' => 'api/v1'], function () use ($router) {
             $router->get('appointments', ['uses' => 'AppointmentController@fetch', 'as' => 'appointments.fetch']);
         });
 
+        $router->get('', ['uses' => 'UserController@fetch', 'as' => 'users.fetch']);
         $router->get('appointments', ['uses' => 'AppointmentController@fetch', 'as' => 'appointments.fetch']);
     });
 });

--- a/src/Http/Controllers/UserController.php
+++ b/src/Http/Controllers/UserController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\User;
+use Illuminate\Http\Request;
 
 /**
  * User Controller
@@ -11,7 +12,7 @@ use App\User;
  */
 class UserController extends Controller
 {
-    public function fetch()
+    public function fetch(Request $request)
     {
         if (!auth()->user()->is_admin) {
             return response()->json([
@@ -21,7 +22,27 @@ class UserController extends Controller
         }
 
         try {
-            return response()->json(['status' => true, 'data' => User::all()]);
+            $filters = [];
+            if ($request->has('active')) {
+                $filters['is_active'] = boolval($request->query('active', 0));
+            }
+
+            if ($request->has('patient')) {
+                $filters['is_patient'] = boolval($request->query('patient', 0));
+            }
+
+            if ($request->has('specialist')) {
+                $filters['is_specialist'] = boolval($request->query('specialist', 0));
+            }
+
+            if ($request->has('admin')) {
+                $filters['is_admin'] = boolval($request->query('admin', 0));
+            }
+
+            $perPage = $request->query('chunk', 10); //chunk-size of fetched-data
+            return response()->json([
+                'status' => true, 'data' => User::with(['patient', 'specialist'])->where($filters)->paginate($perPage)
+            ]);
         } catch (\Exception $e) {
             return response()->json([
                 'status' => false, 'message' => 'User(s) could not be fetched', 'errors' => ['error' => $e->getMessage()]

--- a/src/Http/Controllers/UserController.php
+++ b/src/Http/Controllers/UserController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\User;
+
+/**
+ * User Controller
+ * 
+ * @author Emma NWAMAIFE <emadimabua@gmail.com>
+ */
+class UserController extends Controller
+{
+    public function fetch()
+    {
+        if (!auth()->user()->is_admin) {
+            return response()->json([
+                'status' => false, 'message' => 'User(s) could not be fetched',
+                'errors' => ['error' => "You don't have permission to do use this feature"]
+            ], 401);
+        }
+
+        try {
+            return response()->json(['status' => true, 'data' => User::all()]);
+        } catch (\Exception $e) {
+            return response()->json([
+                'status' => false, 'message' => 'User(s) could not be fetched', 'errors' => ['error' => $e->getMessage()]
+            ],  400);
+        }
+    }
+}


### PR DESCRIPTION
## Description
This change implements the fetch-all-users strictly-administrative feature to enable administrators of the platform to have an holistic view of registered users

Fixes #30 , Fixes #37 

## Test Specs
- User cannot view all registered users list if not authenticated
- User cannot view all registered users list if not an administrator
- User can view all registered users list only if an administrator
- Users List Can Be Filtered To Retrieve Only Specialists With Pagination

### Test Environment
- Sqlite (in-memory)

## Checklist:
<!--- Put an `x` in all the boxes that apply ! -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added necessary inline code documentation
- [x] I have added tests that prove my fix is effective and that this feature works
- [x] New and existing unit tests pass locally with my changes
