### PR TITLE
view-user-profile feature

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -25,17 +25,20 @@ $router->group(['prefix' => 'api/v1'], function () use ($router) {
     });
 
     $router->group(['prefix' => 'users', 'middleware' => 'auth'], function () use ($router) {
+        $router->get('appointments', ['uses' => 'AppointmentController@fetch', 'as' => 'appointments.fetch']);
+
         $router->group(['prefix' => '{id}'], function () use ($router) {
-            $router->post('reviews', ['uses' => 'ReviewController@add', 'as' => 'review.add']);
-            $router->put('reviews/{reviewId}', ['uses' => 'ReviewController@edit', 'as' => 'review.edit']);
-            $router->get('reviews', ['uses' => 'ReviewController@view', 'as' => 'review.view']);
+            $router->post('reviews', ['uses' => 'ReviewController@add', 'as' => 'reviews.add']);
+            $router->put('reviews/{reviewId}', ['uses' => 'ReviewController@edit', 'as' => 'reviews.edit']);
+            $router->get('reviews', ['uses' => 'ReviewController@fetch', 'as' => 'reviews.fetch']);
 
             $router->post('appointments', ['uses' => 'AppointmentController@book', 'as' => 'appointments.book']);
             $router->get('appointments', ['uses' => 'AppointmentController@fetch', 'as' => 'appointments.fetch']);
+
+            $router->get('', ['uses' => 'UserController@view', 'as' => 'users.view']);
         });
 
         $router->get('', ['uses' => 'UserController@fetch', 'as' => 'users.fetch']);
-        $router->get('appointments', ['uses' => 'AppointmentController@fetch', 'as' => 'appointments.fetch']);
     });
 });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,6 +26,7 @@ $router->group(['prefix' => 'api/v1'], function () use ($router) {
 
     $router->group(['prefix' => 'users', 'middleware' => 'auth'], function () use ($router) {
         $router->get('appointments', ['uses' => 'AppointmentController@fetch', 'as' => 'appointments.fetch']);
+        $router->get('me', ['uses' => 'UserController@view', 'as' => 'users.view']);//personal-profile
 
         $router->group(['prefix' => '{id}'], function () use ($router) {
             $router->post('reviews', ['uses' => 'ReviewController@add', 'as' => 'reviews.add']);

--- a/src/Http/Controllers/ReviewController.php
+++ b/src/Http/Controllers/ReviewController.php
@@ -94,16 +94,14 @@ class ReviewController extends Controller
         }
     }
 
-    public function view($id)
+    public function fetch($id)
     {
         try {
             $user = auth()->user();
-            $specialistId = ($user->is_specialist) ? $user->id : $id;
+            $specialistId = ($user->is_specialist && !($user->is_patient || $user->is_admin)) ? $user->id : $id; // TODO: fix this issue
 
             $reviews = Review::where(['specialist_id' => $specialistId])->get();
-            return response()->json([
-                'status' => true, 'data' => $reviews
-            ]);
+            return response()->json(['status' => true, 'data' => $reviews]);
         } catch (\Exception $e) {
             return response()->json([
                 'status' => false, 'message' => 'Review(s) could not be fetched',

--- a/src/Http/Controllers/UserController.php
+++ b/src/Http/Controllers/UserController.php
@@ -55,16 +55,16 @@ class UserController extends Controller
     {
         try {
             $authUser = auth()->user();
+            $viewedUser = User::findOrFail(empty($id) ? $authUser->id : $id);
 
-            $userId = empty($id) ? $authUser->id : $id;
-            $viewedUser = User::findOrFail($userId);
+            if ($authUser->id !== $viewedUser->id) {
+                if (!$authUser->is_admin && $viewedUser->is_admin) {
+                    throw new \Exception("You cannot view this profile");
+                }
 
-            if (($authUser->id !== $viewedUser->id) && !$authUser->is_admin && $viewedUser->is_admin) {
-                throw new \Exception("You cannot view this profile");
-            }
-
-            if (($authUser->id !== $viewedUser->id) && ($authUser->is_patient && $viewedUser->is_patient)) {
-                throw new \Exception("You cannot view a patient as a patient");
+                if ($authUser->is_patient && $viewedUser->is_patient) {
+                    throw new \Exception("You cannot view a patient as a patient");
+                }
             }
 
             $attachment = [];
@@ -76,7 +76,7 @@ class UserController extends Controller
             } else if ($viewedUser->is_specialist) {
                 $attachment = [
                     'specialist' => $viewedUser->specialist,
-                    'appointments' => empty($viewedUser->specialist) ? null : $viewedUser->specialist->appointments,
+                    'appointments' => empty($viewedUser->specialist) ? null : $viewedUser->specialist->appointments
                 ];
             }
 

--- a/src/Http/Controllers/UserController.php
+++ b/src/Http/Controllers/UserController.php
@@ -18,7 +18,7 @@ class UserController extends Controller
         if (!auth()->user()->is_admin) {
             return response()->json([
                 'status' => false, 'message' => 'User(s) could not be fetched',
-                'errors' => ['error' => "You don't have permission to do use this feature"]
+                'errors' => ['error' => "You cannot use this feature"]
             ], 401);
         }
 

--- a/src/Http/Controllers/UserController.php
+++ b/src/Http/Controllers/UserController.php
@@ -24,19 +24,19 @@ class UserController extends Controller
         try {
             $filters = [];
             if ($request->has('active')) {
-                $filters['is_active'] = boolval($request->query('active', 0));
+                $filters['is_active'] = (bool) ($request->query('active', 0));
             }
 
             if ($request->has('patient')) {
-                $filters['is_patient'] = boolval($request->query('patient', 0));
+                $filters['is_patient'] = (bool) ($request->query('patient', 0));
             }
 
             if ($request->has('specialist')) {
-                $filters['is_specialist'] = boolval($request->query('specialist', 0));
+                $filters['is_specialist'] = (bool) ($request->query('specialist', 0));
             }
 
             if ($request->has('admin')) {
-                $filters['is_admin'] = boolval($request->query('admin', 0));
+                $filters['is_admin'] = (bool) ($request->query('admin', 0));
             }
 
             $perPage = $request->query('chunk', 10); //chunk-size of fetched-data
@@ -46,7 +46,7 @@ class UserController extends Controller
         } catch (\Exception $e) {
             return response()->json([
                 'status' => false, 'message' => 'User(s) could not be fetched', 'errors' => ['error' => $e->getMessage()]
-            ],  400);
+            ], 400);
         }
     }
 }


### PR DESCRIPTION
## Description
This change implements the view-profile feature so that users on this platform can can have their profiles viewed

Fixes #11 , Fixes #5 

## Test Strategy
- Users can view their personal profile
- User cannot view a patient profile if not a specialist
- User can view a specialist profile whether or not a specialist
- User cannot view administrative user if not a fellow administrator

### Test Environment
- Sqlite
- in-memory connection


## Checklist:
<!--- Put an `x` in all the boxes that apply ! -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added necessary inline code documentation
- [x] I have added tests that prove my fix is effective and that this feature works
- [x] New and existing unit tests pass locally with my changes
