### PR TITLE
fetch-specialist-recommendations-feature

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -26,8 +26,10 @@ $router->group(['prefix' => 'api/v1'], function () use ($router) {
 
     $router->group(['prefix' => 'users', 'middleware' => 'auth'], function () use ($router) {
         $router->get('appointments', ['uses' => 'AppointmentController@fetch', 'as' => 'appointments.fetch']);
-        $router->get('me', ['uses' => 'UserController@view', 'as' => 'users.view']);//personal-profile
 
+        $router->get('me', ['uses' => 'UserController@view', 'as' => 'users.view']); //personal-profile
+        $router->get('recommendations', ['uses' => 'UserController@recommend', 'as' => 'users.recommend']);
+        
         $router->group(['prefix' => '{id}'], function () use ($router) {
             $router->post('reviews', ['uses' => 'ReviewController@add', 'as' => 'reviews.add']);
             $router->put('reviews/{reviewId}', ['uses' => 'ReviewController@edit', 'as' => 'reviews.edit']);

--- a/src/Http/Controllers/UserController.php
+++ b/src/Http/Controllers/UserController.php
@@ -15,7 +15,7 @@ class UserController extends Controller
 {
     public function fetch(Request $request)
     {
-        if (!auth()->user()->is_admin) {
+        if (!auth()->user()->is_admin && !($request->routeIs('users.recommend') && $request->input('byrr'))) {
             return response()->json([
                 'status' => false, 'message' => 'User(s) could not be fetched',
                 'errors' => ['error' => "You cannot use this feature"]
@@ -49,6 +49,21 @@ class UserController extends Controller
                 'status' => false, 'message' => 'User(s) could not be fetched', 'errors' => ['error' => $e->getMessage()]
             ], 400);
         }
+    }
+
+    /**
+     * Recommend a specialist to the current user [based on their location - W.I.P]
+     * (should work like a recommendation-engine for mental-health specialists like Youtube e.t.c)
+     * 
+     * @see https://medium.com/@sirajul.anik/laravel-lumen-manipulating-route-controller-parameters-5f3cbcb521b4
+     * @param Request $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function recommend(Request $request)
+    {
+        return $this->fetch($request->merge([
+            'specialist' => 1, 'active' => 1, 'patient' => 0, 'admin' => 0, 'byrr' => true // byrr => by-recommend-route
+        ]));
     }
 
     public function view($id = 0)


### PR DESCRIPTION
## Description
This change implements the feature for fetching recommendations of specialists for consultation

Fixes #12, Fixes #9 

## How Has This Been Tested?
- User Can Fetch Specialists-Recommendations For Consultation In Pages

## Checklist:
<!--- Put an `x` in all the boxes that apply ! -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added necessary inline code documentation
- [x] I have added tests that prove my fix is effective and that this feature works
- [x] New and existing unit tests pass locally with my changes
